### PR TITLE
chore: npm auth environment changes

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
@@ -14,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - uses: jaywcjlove/github-action-package@main
         with:
@@ -22,5 +26,3 @@ jobs:
           rename: "@gofynd/theme-template"
       - run: npm ci
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}


### PR DESCRIPTION
### What’s changed
- Updated npm authentication / environment configuration
- Aligns setup with latest npm security requirements (token-based auth)

### Why
- npm no longer supports password-based authentication
- Ensures CI / publish workflows continue to work without interruption

### Notes
- No functional runtime changes
- Safe to merge